### PR TITLE
test: esmock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "esmock": "^1.7.7",
         "tap": "^16.3.0"
       }
     },
@@ -793,6 +794,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esmock": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-1.7.7.tgz",
+      "integrity": "sha512-2jxZf9z5/amfB6LLhwD/a1BLi13kNIAAdtEfNrOE+rn3nyUGL/dEl2p1j1h3VXXDhD9FEW5Q7De9w/5LgmZieg==",
+      "dev": true,
+      "dependencies": {
+        "resolvewithplus": "^0.8.0"
       }
     },
     "node_modules/esprima": {
@@ -1711,6 +1721,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/resolvewithplus": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/resolvewithplus/-/resolvewithplus-0.8.0.tgz",
+      "integrity": "sha512-k2ZTNmYyHjSVMswoitU9I5C0It/Jgs/4+oVSz2Tg9zgW4oURz3FSeHjAAbSau8W+njdBwfWVjFxl45B9cprWTw==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -4809,6 +4825,15 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
+    "esmock": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/esmock/-/esmock-1.7.7.tgz",
+      "integrity": "sha512-2jxZf9z5/amfB6LLhwD/a1BLi13kNIAAdtEfNrOE+rn3nyUGL/dEl2p1j1h3VXXDhD9FEW5Q7De9w/5LgmZieg==",
+      "dev": true,
+      "requires": {
+        "resolvewithplus": "^0.8.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -5482,6 +5507,12 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true
+    },
+    "resolvewithplus": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/resolvewithplus/-/resolvewithplus-0.8.0.tgz",
+      "integrity": "sha512-k2ZTNmYyHjSVMswoitU9I5C0It/Jgs/4+oVSz2Tg9zgW4oURz3FSeHjAAbSau8W+njdBwfWVjFxl45B9cprWTw==",
       "dev": true
     },
     "rimraf": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "test": "tap"
+    "test": "tap --node-arg=\"--loader=esmock\""
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "esmock": "^1.7.7",
     "tap": "^16.3.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,12 +1,9 @@
 import { test } from 'tap'
+import esmock from 'esmock'
 
-test('isMemoryAvailable', t => {
-  t.plan(1)
-
-  t.test('should return false if memory === 0', t => {
-    t.plan(1)
-
-    const mockedIndexModule = t.mock('./src/index', {
+test('isMemoryAvailable', async t => {
+  t.test('should return false if memory === 0', async t => {
+    const mockedIndexModule = await esmock('../src/index.js', {
       os: {
         freemem: () => 0
       }


### PR DESCRIPTION
It turns out neither tap nor proxyquire support mocking es modules. It's a good find, and luckily somebody created something which works with es modules.